### PR TITLE
TNV-37: Copy data to shared memory when sending USB packets and copy …

### DIFF
--- a/dts/bindings/usb/lattice,usb23.yaml
+++ b/dts/bindings/usb/lattice,usb23.yaml
@@ -16,3 +16,6 @@ properties:
   auto-endpoint:
     required: false
     type: array
+  shared-buffer:
+    required: true
+    type: int


### PR DESCRIPTION
…out data from shared memory when receiving data

This PR fixes Zephyr's CDC ACM driver to properly use shared memory buffer for USB23 IP core communication.
Base address of shared memory buffer added to Application settings, by default it is set to 0xb1000800
This PR allows running Zephyrs' shell on CDC ACM device

Unit test:
o) Open terminal on `/dev/ttyACM0` device
o) Observe shell prompt 
o) Type 'device list' to request devices list
o) Observe device list displayed